### PR TITLE
Allow use of ctrl + c to exit the repl through an environment variable

### DIFF
--- a/source/prompt.ts
+++ b/source/prompt.ts
@@ -359,15 +359,27 @@ export default function promptLine({
 			} else if (ctrl && name === 'd') {
 				stop()
 
+				if (process.env.QUIT_W_C){
+					if (rl.line === '') {
+						stdout.write(c.gray(`Press \`${c.bold('ctrl+c')}\` to exit.\n`))
+					}
+
+					return resolve([Commands.Abort, {}])
+				}
+
 				return resolve([Commands.Exit, {}])
 			} else if (ctrl && name === 'c') {
 				stop()
 
-				if (rl.line === '') {
-					stdout.write(c.gray(`Press \`${c.bold('ctrl+d')}\` to exit.\n`))
+				if (!process.env.QUIT_W_C){
+					if (rl.line === '') {
+						stdout.write(c.gray(`Press \`${c.bold('ctrl+d')}\` to exit.\n`))
+					}
+
+					return resolve([Commands.Abort, {}])
 				}
 
-				return resolve([Commands.Abort, {}])
+                                return resolve([Commands.Exit, {}])
 			} else if (ctrl && name === 'l') {
 				stdout.write(ansiEscapes.cursorTo(0, 0))
 				stdout.write(ansiEscapes.eraseDown)


### PR DESCRIPTION
If QUIT_W_C (quit with c) variable exists, switch the exit command from CTRL+D to CTRL+C

There's definitely a nicer way to do this, but it means that an alias can be set up for example, and that ctrl+d remains the default.

Personally, I'm in the habit of hitting ctrl+c a few times, and doing the same with ctrl+d often ends in accidentally terminating my bash session, so being able to switch it to ctrl+c is preferable.